### PR TITLE
update: changelogs and remove deprecated pricebook references

### DIFF
--- a/docs/web_sdk/Changelog.md
+++ b/docs/web_sdk/Changelog.md
@@ -4,6 +4,24 @@ sidebar_position: 12
 
 ## Changelog
 
+## v9.2.4 - [23/06/2025]
+
+#### Removed:
+- *pricebook*:
+  - No more used, we removed all related code
+
+## v9.2.3 - [10/06/2025]
+
+#### Fixed:
+- Accessibility fixes on recipes picture aria-hidden, badge alt and role lists
+
+## v9.2.2 - [09/06/2025]
+
+#### Updated:
+Improved accessibility across components (recipe-details, counter-input, like-button, modal ...) following French RGAA standards
+
+Merged 9.1.15 in 9.2 -> See v9.1.15 for changes
+
 ## v9.2.1 - [31/03/2025]
 
 #### Fixed:

--- a/docs/web_sdk/customization/window-mealz.md
+++ b/docs/web_sdk/customization/window-mealz.md
@@ -37,10 +37,6 @@ props: {aString: 'foo bar', aNumber: 5}
     
     Outside of this usage we don't recommand using `basket.reset()` except to quickly empty Mealz's basket for testing purposes
   :::
-- `updatePricebook: (pricebookName: string) => Observable<void>`: If you have different price tables (or pricebooks) for the same point of sale, you can call this method to let Mealz know which pricebook you are using. For example, prices could be different depending on if the user chose home delivery or drive-in
-  :::info
-    If you have different pricebooks, they need to have been sent to our API so you can change them with `basket.updatePricebook()`. The pricebookName should be the same that the one sent to our API
-  :::
 - `recipeCount: () => Observable<number>`: A BehaviorSubject that emits the current number of recipes in Mealz' Basket once (it waits for the Basket to be initialized to emit).
 - `openPreview: () => void`: Opens the recipe-modal in basket preview mode to display the recipes currently in the basket (Same action as when clicking on the FAB in the recipe-catalog)
 - `overrideTransferUrl: (url: string)`: Use in the devtools on an affiliated website to override the redirection url when transferring the cart to your website.

--- a/docs/web_ssr/changelog/changelog-lit.md
+++ b/docs/web_ssr/changelog/changelog-lit.md
@@ -4,6 +4,56 @@ sidebar_position: 2
 
 # Mealz components Changelog
 
+## 1.3.6 [23/06/2025]
+
+#### Updated:
+- *recipe-pricing*:
+  - Reorder some logic as some variables were not set properly
+- *recipe-card*:
+  - Now listens on recipe  to fetch the updated number of guests
+
+#### Deleted:
+- *pricebook*
+  - Remove deprecated pricebook parameters
+
+## 1.3.5 [16/06/2025]
+
+#### Fixed:
+- *catalog-favorites*
+  - Fixed 'pageView' event not sended if user has no favorites
+
+## 1.3.4 [10/06/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - Revert previous changes
+
+## 1.3.3 [10/06/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - If render is called and price is defined, update the view
+
+## 1.3.2 [06/06/2025]
+
+#### Updated:
+- *recipe-card-cta*:
+  - Style for new hidden class & remove hidden class after the basket data has been fetched & the CTA can be displayed when personalization is disabled
+- *like-button*:
+  - When personalization is disabled, fetch the like & update the DOM manually
+
+#### Fixed:
+- *catalog-history*:
+  - Empty view was inconsistent with the ones from the other pages
+  - Added missing pageview event
+
+## 1.3.1 [23/05/2025]
+
+#### Fixed:
+- *history-order-expanded*:
+  - card width was inconsistent
+
+
 ## 1.3.0 [23/05/2025]
 
 #### Added:

--- a/docs/web_ssr/changelog/changelog-nest.md
+++ b/docs/web_ssr/changelog/changelog-nest.md
@@ -4,6 +4,69 @@ sidebar_position: 1
 
 # Mealz SSR API Changelog
 
+## 1.3.7 [23/06/2025]
+
+#### Fixed:
+- *demo/retailer-cart*:
+  - Optimized cart updates by only triggering the retailerBasketChanged event once after adding multiple products instead of after each individual product
+- *recipe-card*:
+  - Fixed recipe card basket detection when using suggested recipes, ensuring correct guest count is displayed for recipe cards loaded via product suggestions
+
+#### Deleted:
+- *pricebookKey*:
+  - Remove deprecated variable pricebookKey
+
+## 1.3.6 [16/06/2025]
+
+#### Fixed:
+- *recipe-card*:
+  - Fixed issue where all recipe cards in multiple route used the same guest count instead of respecting individual recipe guest settings
+- *recipe-pricing*:
+  - Fixed issue where recipe cards in catalog home beyond the first two categories used a hardcoded guest count of 4 instead of the recipe's actual guest count
+
+## 1.3.5 [11/06/2025]
+
+#### Internal:
+- *recipe-card*:
+  - Added logs for /multiple route body
+  - Added error handling for /multiple body
+
+## 1.3.4 [10/06/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - Revert previous changes
+
+## 1.3.3 [10/06/2025]
+
+#### Updated:
+- If render if called and price is defined, update the view
+
+## 1.3.2 [06/06/2025]
+
+#### Fixed:
+- *catalog*:
+  - All /load-more routes were missing `shouldRemovePersonalization: false` 
+
+## 1.3.1 [06/06/2025]
+
+#### Added:
+- *styles*:
+  - Added /styles/catalog/my-space which corresponds to the styles for the /my-space route. It combines the previous routes /styles/catalog/catalog-history & /styles/catalog/catalog-favorites
+
+#### Updated:
+- *recipe-card*:
+  - Added a global configuration in supplier-tokens to disable personalization in both recipe-card routes. When disabled, the pre-rendered recipes-cards will not display the like button nor the cart CTA at prerender, and both will be displayed client-side, to avoid issues with caching between users.
+  - /multiple route now uses the new suggestion-batch route from miam-api for better performances
+- *preferences*:
+  - Preferences are disabled if personalization is disabled, meaning the button will not be rendered and if the user had any preferences set, they are removed
+
+#### Fixed:
+- *recipe-card*
+  - The /multiple route now returns a JSON array of the recipe cards instead of one HTML
+- *my-space*:
+  - Added missing paths in startingData for favorites & history
+
 ## 1.3.0 [23/05/2025]
 
 #### Updated:

--- a/docs/web_ssr/customization/order-history.md
+++ b/docs/web_ssr/customization/order-history.md
@@ -46,10 +46,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/catalog/my-space
     
     **_(Optional)_** Specify the style to display for the history tab: grid (default) or list. Does not have any effect if used alongside `tab=favorites`. **(See [Routing](/docs/web_ssr/customization/order-history#routing))**
 
-  - `pricebook_key: string = 'DEFAULT'`:
-    
-    **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
-
   - `display_infos: boolean = false`:
     
     **_(Optional)_** By default, the recipe-cards doesn't show the preparation time and difficulty af the recipe but if you want to display them you can set display_infos to true

--- a/docs/web_ssr/customization/window-mealz.md
+++ b/docs/web_ssr/customization/window-mealz.md
@@ -35,10 +35,6 @@ props: {aString: 'foo bar', aNumber: 5}
     
     Outside of this usage we don't recommand using `basket.reset()` except to quickly empty Mealz's basket for testing purposes
   :::
-- `updatePricebook: (pricebookName: string) => Observable<void>`: If you have different price tables (or pricebooks) for the same point of sale, you can call this method to let Mealz know which pricebook you are using. For example, prices could be different depending on if the user chose home delivery or drive-in
-  :::info
-    If you have different pricebooks, they need to have been sent to our API so you can change them with `basket.updatePricebook()`. The pricebookName should be the same that the one sent to our API
-  :::
 - `recipeCount: () => Observable<number>`: A BehaviorSubject that emits the current number of recipes in Mealz's Basket once (it waits for the Basket to be initialized to emit).
 - `openPreview: () => void`: Opens the recipe-modal in basket preview mode to display the recipes currently in the basket (Same action as when clicking on the FAB in the recipe-catalog)
 

--- a/docs/web_ssr/main-features/recipe-card.md
+++ b/docs/web_ssr/main-features/recipe-card.md
@@ -31,9 +31,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/recipe-card
   - `store_id: string`:
   **_(Recommended)_** We need your store ID to display the price of the recipe, so ideally it should be passed if the user has chosen a store
 
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
-
   - `display_variant: number = 1`:
   **_(Optional)_** Select the variant for the display of the card. Default is 1, available values are 1, 2 and 3 (see below for examples)
 
@@ -57,13 +54,13 @@ Do not forget the [mandatory HTTP headers](./pre-rendered-components#http-reques
 A recipe contextualized with surrounding products **_(Recommended)_**:
 
 ```
-GET https://MEALZ_SSR_API_URL/API_VERSION/recipe-card?surrounding_products_ids=["214086","1254022"]&store_id=2817&pricebook_key=DEFAULT&serves=4&profiling=true&display_variant=3&orientation=horizontal
+GET https://MEALZ_SSR_API_URL/API_VERSION/recipe-card?surrounding_products_ids=["214086","1254022"]&store_id=2817&serves=4&profiling=true&display_variant=3&orientation=horizontal
 ```
 
 A fixed recipe:
 
 ```
-GET https://MEALZ_SSR_API_URL/API_VERSION/recipe-card?recipe_id=15123&store_id=2817&pricebook_key=DEFAULT&serves=4&profiling=true&display_variant=3&orientation=horizontal
+GET https://MEALZ_SSR_API_URL/API_VERSION/recipe-card?recipe_id=15123&store_id=2817&serves=4&profiling=true&display_variant=3&orientation=horizontal
 ```
 
 ### Display variants
@@ -121,9 +118,6 @@ POST https://MEALZ_SSR_API_URL/API_VERSION/recipe-card/multiple
 - Parameters :
   - `store_id: string`:
   **_(Recommended)_** We need your store ID to display the price of the recipe, so ideally it should be passed if the user has chosen a store
-
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
 
   - `display_variant: number = 1`:
   **_(Optional)_** Select the variant for the display of the card. Default is 1, available values are 1, 2 and 3 (see below for examples)

--- a/docs/web_ssr/main-features/recipe-catalog.md
+++ b/docs/web_ssr/main-features/recipe-catalog.md
@@ -53,9 +53,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/catalog
   - `max_recipes_per_category = 6`:
   **_(Recommended)_** Specify a maximum number of recipes to display per category. In our base design, we have 1 row of recipes per category and recipes should ideally fill the space available. So it is in your interest to fetch exactly the number of recipes that can be displayed on 1 row on the user's screen.
 
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
-
   - `display_infos: boolean = false`:
   **_(Optional)_** By default, the recipe-cards doesn't show the preparation time and difficulty af the recipe but if you want to display them you can set display_infos to true
 
@@ -86,9 +83,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/catalog/category
   - `store_id: string`:
   **_(Recommended)_** We need your store ID to display the prices of the recipes, to fetch the recipes in basket informations and to hide recipes with primary ingredients not available in your store, so ideally it should be passed if the user has chosen a store
 
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
-
   - `display_infos: boolean = false`:
   **_(Optional)_** By default, the recipe-cards doesn't show the preparation time and difficulty af the recipe but if you want to display them you can set display_infos to true
 
@@ -109,9 +103,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/catalog/favorites
   - `store_id: string`:
   **_(Recommended)_** We need your store ID to display the prices of the recipes, to fetch the recipes in basket informations and to hide recipes with primary ingredients not available in your store, so ideally it should be passed if the user has chosen a store
 
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
-
   - `display_infos: boolean = false`:
   **_(Optional)_** By default, the recipe-cards doesn't show the preparation time and difficulty af the recipe but if you want to display them you can set display_infos to true
 
@@ -131,9 +122,6 @@ GET https://MEALZ_SSR_API_URL/API_VERSION/catalog/list
 - Parameters :
   - `store_id: string`:
   **_(Recommended)_** We need your store ID to display the prices of the recipes, to fetch the recipes in basket informations and to hide recipes with primary ingredients not available in your store, so ideally it should be passed if the user has chosen a store
-
-  - `pricebook_key: string = 'DEFAULT'`:
-  **_(Optional)_** the pricebook key is needed to retrieve the recipe price corresponding to the pricebook you are currently using. If your website doesn't have multiple pricebooks for the same store, this parameter is not needed.
 
   - `display_infos: boolean = false`:
   **_(Optional)_** By default, the recipe-cards doesn't show the preparation time and difficulty af the recipe but if you want to display them you can set display_infos to true

--- a/web_sdk_versioned_docs/version-9.1/Changelog.md
+++ b/web_sdk_versioned_docs/version-9.1/Changelog.md
@@ -4,6 +4,73 @@ sidebar_position: 12
 
 ## Changelog
 
+## v9.1.19 - [23/06/2025]
+
+#### Updated:
+- *mealzInternal*:
+  - Replaced `recipePricesInBasket$` to `recipeDataInBasket$` and added `guests` to attributes
+
+#### Removed:
+- *pricebook*:
+  - No more used, we removed all related code
+
+## v9.1.18 - [16/06/2025]
+
+#### Updated:
+- *basket-recipe-cleanup*:
+  - Now when adding product(s), if it fails, it checks if the recipe has active entries, if not it removes the recipe from users basket
+- *recipe-modal*:
+  - Removed singleton service unsubscribe to prevent listener stopping
+
+#### Fixed:
+- *recipe-modal*: Fixed store-locator behavior to only open in noSupplier mode and prevent opening when PoS hasn't loaded
+- *recipes*
+  - Resolved an issue where the `loadRecipes` function failed to load recipe titles when reloading the view, causing the recipe titles to appear blank in the basket preview
+
+## v9.1.17 - [10/06/2025]
+
+#### Updated:
+- Update wording for last order title in recipe-details, title and text in last-order modal
+
+## v9.1.16 - [05/06/2025]
+
+#### Internal:
+- *mealzInternal*:
+  - Added *recipes.getRecipeLike* to fetch the recipe-like for a recipeId
+
+## v9.1.15 - [25/04/2025]
+
+#### Updated:
+- *my-meals*:
+  - Now when removing every active ingredients from a meal, it gets removed from the basket
+
+#### Internal:
+- *basket-recipe-cleanup*:
+  - Created service to handle removing recipe without active basket entries 
+
+## v9.1.14 - [18/04/2025]
+
+#### Fixed:
+- *product-card*:
+  - Out of stock overlay now adapts to header height
+- *out-of-stock*:
+  - Now when succeeding in adding a product out-of-stock, it removes it from storage and prevent forcing the status from 'active' to 'out_of_stock'
+- *miam-ds*:
+  - Update to 1.2.6
+
+## v9.1.13 - [14/04/2025]
+
+Merged 9.0.11 in 9.1 -> See v9.0.11 for changes
+
+#### Fixed:
+- *recipe-details*:
+  - Fixed issue where updating guest number tried to update "deleted" ingredients
+
+#### Updated:
+- *replace-item*:
+  - Prevent adding out-of-stock products by disabling CTA
+  - On replace time out, it navigates to previous page rather than just removing loaders 
+
 ## v9.1.12 - [04/04/2025]
 
 #### Fixed:


### PR DESCRIPTION
- Added new version entries for v9.2.4 and v1.3.7, detailing removals and updates.
- Added all missing version in changelogs
- Removed all mentions of the deprecated pricebook parameter from various documentation files.