### PR TITLE
docs: sync changelogs (SSR API / components)

### DIFF
--- a/docs/web_ssr/changelog/changelog-lit.md
+++ b/docs/web_ssr/changelog/changelog-lit.md
@@ -4,11 +4,42 @@ sidebar_position: 2
 
 # Mealz components Changelog
 
-## 2.6.3 [Unreleased]
+## 2.7.1 [26/03/2026]
+
+#### Fixed
+- *mealz-modal*
+  - Added `createMealzModal()` to create modal instances via `document.createElement('mealz-modal')` instead of `new MealzModal()`, preventing "Illegal constructor" when several script bundles register the same tag with different class references.
+- *planner modals* (onboarding, welcome, abandon, budget edit, current menu, open catalog)
+  - All planner flows that open `mealz-modal` now use `createMealzModal()`.
+
+## 2.7.0 [19/03/2026]
+
+#### Added
+- *basket-preview*
+  - Added `hide-tab-selector` attribute to hide the recipes/products tab selector when used in standalone drawer.
+- *drawer-view-swapper*
+  - Added `displayBasketDrawer$` BehaviorSubject to open basket preview as standalone drawer with configurable title and showTabSelector.
+- *init-basket-preview-drawer*
+  - New helper script for SSR-injected pages: opens basket preview in drawer on load, reads title and show_tab_selector from URL params.
+
+#### Updated
+- *drawer-view-swapper*
+  - Basket preview now supports both inline (isBasketPreviewVisible) and standalone (isBasketDrawerVisible) display modes.
+  - Header title reflects basket drawer title when opened standalone.
+- *planner-recipe-suggestion*
+  - Refactor layout and height properties for improved responsiveness: changed display from block to flex and adjusted height to 75% for better alignment; removed fixed min-height and top positioning for a more fluid design; updated padding for mobile view to enhance spacing
+- *planner-recipe-list*
+  - Placeholder logic: always show at least 6 recipe card slots (fill with placeholders when fewer than 6 recipes); when 6+ recipes, add a trailing placeholder so users know they can add more
+- *menu-title*
+  - Now the menu title is always "Mon menu" and does not depend on the menu origin anymore. We also removed the date of creation of the menu
+- *mealz-planner-menu-option*
+  - On navigation, we add a loader
 
 #### Fixed
 - *basket-transfert-modal*
   - Fix define component was `mealz-basket-preview` instead `mealz-basket-transfert-modal`
+- *open-onboarding-modal*
+  - Planner onboarding can now be reopened via the help (?) button even after choosing to skip onboarding
 
 ## 2.6.2 [03/03/2026]
 
@@ -53,7 +84,7 @@ sidebar_position: 2
 
 #### Updated
 - *planner*
-  Can now add recipe to menu without having to be authenticated. authentication is required when trying to push menu to Basket
+  Can now add recipe to menu without having to be authenticated. authentication is required when trying to push menu to basket
 - *products-to-basket-cta*:
   - SSR-hydratable CTA to add all remaining recipe ingredients to basket
   - Sends analytics event `entry.add-all` with `recipe_id` and `entry_count`
@@ -431,7 +462,6 @@ sidebar_position: 2
 - *loader*:
   - Renamed animation from `miam-loader-spin` to `mealz-loader-spin`
 
-
 ## 2.0.0-beta.9 [09/10/2025]
 
 #### Fixed:
@@ -449,6 +479,7 @@ sidebar_position: 2
 #### Updated:
 - *recipe-details*:
   - in meals planner, when adding recipe to the menu, it closes automatically the recipe details modal
+
 
 ## 2.0.0-beta.8 [29/09/2025]
 
@@ -607,3 +638,520 @@ Upgraded from `miam-ds@1.2.6` to `mealz-ds@2.0.0`. The design system was renamed
 - Refactored all components to use `mealzInternal` and `mealz` import instead of `window.mealzInternal` and `window.mealz`
 - Enhanced menu redirection logic in planner components
 - Adjusted `recipe-card` and `details-footer` to forward `toPickProducts` to `mealzInternal.planner.addRecipeToMenu`
+
+## 1.3.15 - [04/12/2025]
+
+#### Fixed
+- *recipe-priging*
+  - Fix hidden display overrided by retailer
+
+## 1.3.14 - [03/12/2025]
+
+#### Updated
+- *recipe-card-cta*, *recipe-pricing*, *like-button*
+  - Update these components to be called individually in dedicated routes
+  
+## 1.3.11 [06/08/2025]
+
+#### Fixed:
+- *recipe-pricing*
+  - Reduce flickering price when re-render component
+- *recipe-card*
+  - Fix multiple event on recipe.show when re-render Component
+
+## 1.3.10 [04/08/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - Fix pricing flickering with loading
+
+## 1.3.9 [04/08/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - Show pricing correctly
+
+## 1.3.8 [31/07/2025]
+
+#### Updated:
+- *like-button*:
+  - Added like data fetching from client-side
+  - Removed async calls, simplified subscription management
+- *recipe-card*:
+  - Added client-side guests retrieval from localStorage preferences
+  - Optimized guests handling with fallback to default value
+- *recipe-pricing*:
+  - Refactored pricing logic to fetch data client-side
+  - Simplified basket data subscription and price recalculation
+
+## 1.3.7 [24/06/2025]
+
+### Fixed:
+- *recipe-card-cta*
+  - Fix displaying CTA when shouldRemovePersonalization is true
+
+## 1.3.6 [23/06/2025]
+
+### Updated:
+- *recipe-pricing*:
+  - Reorder some logic as some variables were not set properly
+- *recipe-card*:
+  - Now listens on recipe  to fetch the updated number of guests
+
+#### Deleted:
+- *pricebook*
+  - Remove deprecated pricebook parameters
+
+## 1.3.5 [16/06/2025]
+
+#### Fixed:
+- *catalog-favorites*
+  - Fixed 'pageView' event not sended if user has no favorites
+
+## 1.3.4 [10/06/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - Revert previous changes
+
+## 1.3.3 [10/06/2025]
+
+#### Fixed:
+- *recipe-pricing*:
+  - If render is called and price is defined, update the view
+
+## 1.3.2 [06/06/2025]
+
+#### Updated:
+- *recipe-card-cta*:
+  - Style for new hidden class & remove hidden class after the basket data has been fetched & the CTA can be displayed when personalization is disabled
+- *like-button*:
+  - When personalization is disabled, fetch the like & update the DOM manually
+
+#### Fixed:
+- *catalog-history*:
+  - Empty view was inconsistent with the ones from the other pages
+  - Added missing pageview event
+
+## 1.3.1 [23/05/2025]
+
+#### Fixed:
+- *history-order-expanded*:
+  - card width was inconsistent
+
+## 1.3.0 [23/05/2025]
+
+#### Added:
+- *basket-preview*:
+  - Added component with interactions
+  - Added component noSupplier mode
+  - Added products view which can be hidden through supplierToken
+  - product views has number of recipes badge and clicking on it shows a modal with the recipe name list
+- *counter*:
+  - Created component
+- *basket-preview-product*:
+  - Created component
+- *mealz-modal*:
+  - Created component
+- *recipe-details*
+  - Added component
+- *skeleton*:
+  - Added CSS class mealz-skeleton-loader that can be imported when needed
+- *store-locator-drawer*
+  - Added component with interactions
+- *history-order-expanded*:
+  - Added new component for the new history display in list mode
+
+#### Updated:
+- *CSS*:
+  - Replaced every color fallbacks occurrence with new colors from miam-ds
+- *drawer*:
+  - Component is now called through HTML tags and content is now passed through HTML slots
+- *no-shadow-element*:
+  - updated styleURL to be an array of URLs or a single URL and update boilerplate to handle it
+- *config*:
+  - Added styles folder to the build input
+- *basket-preview-product*:
+  - Replace basketEntryId property with basketEntry preventing stale data 
+- *slider-tabs*:
+  - Slider now updates visually when selectedTabIndex is changed from parent
+
+#### Internal:
+- *history-drawer*:
+  - The component now uses `drawer-view-swapper`
+- *recipe-addon*:
+  - Added component with interactions
+- *store-indicator*:
+    - Added component with interactions
+- *slider-tabs*:
+    - Added component with inputs / outputs
+- *sponsor-block*:
+  - Added component
+- *utils*:
+    - Add round, capitalize and stopPropagation functions
+- *models*:
+    - Add BasketEntry model
+- *product-addition*:
+  - Added component with interactions
+- *no-shadow-element*:
+  - Add `addStyles` and `removeStyles` boilerplate
+- *price*:
+  - Created component
+- *lang-to-currency*:
+  - Created a map to assign a currency to a language
+- *miam-ds*
+  - Turned miam colors into design system colors
+- *types*:
+  - Add Recipe definition
+  - Add Ingredient definition
+- *vite.config*
+  - Exclude files from build to minimize calls
+
+#### Fixed:
+- *history-order*:
+  - Fixed orders were overlapping
+  - Fixed gap between "Ordered on" and the date
+
+## 1.2.8 [25/04/2025]
+
+#### Fixed:
+- *my-meals-button*:
+  - The arrow could come out of the button of mobile resolutions
+- Removed remaning occurences of miam-ds links as to not have conflicts with the version served by SSR-API
+
+## 1.2.7 [18/04/2025]
+
+#### Fixed:
+- *catalog-toolbar*:
+  - Remove "navigate back" on back button as already set in HTML and was triggering navigate back twice  
+
+## 1.2.6 [18/04/2025]
+
+#### Updated:
+- *catalog-favorites*:
+  - Now if unliking a recipe on the page or on the recipe-details view, the recipe will be removed from the list 
+
+#### Fixed:
+- *load-more*:
+  - Fixed issue where load-more was based on the user scroll position from the bottom of the window and not from the list element
+
+## 1.2.5 [28/03/2025]
+
+#### Fixed:
+- *catalog-favorites*:
+  - Fixed init state was incorrectly set, now the hidden state of the elements are set on prerender and only updated on render
+  - Removed unused loader on start
+
+## 1.2.4 [21/03/2025]
+
+#### Fixed:
+- Recipe-cards CSS was lacking the rules to remove margins on p tags that are in the catalog CSS
+- *catalog-load-more*
+  - The auto-load more recipes on scroll was triggered even when no more recipes were available 
+- *catalog-history*:
+  - The history-order cards now use a CSS variable for their width that uses the same base value as the recipe-cards by default
+- *catalog-toolbar*:
+  - Back button now does a native back action instead of redirecting to the home page
+- *recipe-pricing*:
+  - Prevent price displaying `NaN` When price starting data is null
+
+## 1.2.3 [31/01/2025]
+
+#### Internal
+- *catalog-category*
+  - Added pageview event
+- *catalog-favorites*
+  - Added pageview event
+- *catalog-home*
+  - Added pageview event
+  - Added category.show event, triggered when category is 80% in viewport for 1s
+- *catalog-toolbar*
+  - Added search event
+
+## 1.2.2 [10/01/2025]
+
+#### Added:
+- *catalog*:
+  - Added category.display event on click on "See all" / the title of a category
+
+#### Updated:
+- *headers*:
+  - requests for `load-more` and `drawer` now uses authlessId if needed in authorization header
+
+#### Fixed:
+- *catalog-load-more*
+  - Fixed the auto-load more recipes on scroll for unconnected users
+- *toolbar*:
+  - Added CSS class for toolbar to do full width on Firefox
+- *store-locator*:
+  - In getByCoordinates, lat and lng parameters were inverted
+
+#### Internal:
+- Synchronize the session id with SDK during initialization for the following components:
+  - *catalog-category*
+  - *catalog-favorites*
+  - *catalog-history*
+  - *catalog-home*
+  - *catalog-list*
+  - *recipe-card*
+
+## 1.2.1 [20/12/2024]
+
+#### Added:
+- *catalog*
+    - Added support for store-locator
+- *recipe-promotion*
+  - Added css for component
+- *promotions-banner*
+  - Added css for component, is hidden by default and must be displayed manually
+- *catalog-history*
+  - Added component
+  - Open drawer of the clicked order
+  - Added "no history" view
+- *catalog-tabs*
+  - Added component
+- *drawer*
+  - Added component
+- *history-order*
+  - Added component
+- *recipe-card*
+  - Added style for a new variant
+
+#### Updated:
+- *recipe-card*
+  - Updated some css to match mock ups
+- *viewport-listener*:
+  - Handle unsubscription to prevent memory leaks
+
+#### Fixed:
+- *catalog-favorites*
+  - Fixed an infinite loader issue when the user hadn't marked any recipes as favorites
+
+## 1.2.0 [13/12/2024]
+
+#### Updated:
+- Removed the `starting-data` attribute from HTML after it has been successfully read for the following components:
+  - *catalog-category*
+  - *catalog-favorites*
+  - *catalog-home*
+  - *catalog-list*
+  - *catalog-toolbar*
+  - *recipe-card-cta*
+  - *recipe-pricing*
+
+#### Fixed:
+- Fixed margins & selectors after semantic tags were added in SSR-API
+- *catalog-load-more*
+  - Catch failed requests and log to console instead of displaying in HTML
+  
+#### Internal
+- *recipe-card*
+  - Handle `path` and `categoryId` in starting data for analytics
+  - New recipe.show event sent when recipe-card is 80% in viewport for 1s
+- *catalog-toolbar*
+  - Handle `path` in starting data for analytics
+- *my-meals-button*
+  - Handle starting data with `path` for analytics
+- *viewport-listener*:
+  - Create class
+
+## 1.1.2 [29/11/2024]
+
+#### Fixed:
+- *catalog*
+  - Fix only the home page had a padding at the bottom
+
+## 1.1.1 [25/11/2024]
+
+#### Fixed:
+- *catalog-favorites*
+  - Fix infinite loader
+
+## 1.1.0 [22/11/2024]
+
+#### Added:
+- *catalog-favorites*
+  - Added auto-load more recipes on scroll
+- *catalog-list*
+  - Added auto-load more recipes on scroll
+- *catalog-toolbar*
+  - Added preferences loader
+
+#### Updated:
+- *catalog-toolbar*
+  - Reset stickyObserver when new value is given using mealz.setStickyHeaderHeight(...)
+
+#### Internal:
+- *catalog-load-more*
+  - Added component to group load more functionality
+
+## 1.0.2 [15/11/2024]
+
+#### Added:
+- *catalog*
+ - Added support for preferences
+
+#### Updated:
+- *catalog-toolbar*
+  - Removed unused filters
+
+#### Fixed
+- *catalog-home*:
+  - Added back arrow to "See All" button
+  - Fixed gap issue in category header for smaller screens
+- *like-button*:
+  - Corrected icon color on hover
+- *recipe-card*
+  - Fixed recipe-card width for smaller screens
+- *recipe-pricing*:
+  - Encapsulated hidden and active classes
+
+## 1.0.1 [31/10/2024]
+
+merged 0.6.1 into 1.0. See 0.6.1 for changes
+
+## 1.0.0 [24/10/2024]
+
+#### Breaking changes:
+- *window.miam*:
+  - Renamed to window.mealz
+
+## 0.7.0 [10/01/2025]
+
+#### Added:
+- *store-locator*:
+  - Added 3 new events: filterChange with supplierName as detail, mapSelected, listSelected
+
+## 0.6.1 [31/10/2024]
+
+0.6.0 has been unpublished an thus could not be republished.
+
+## 0.6.0 [31/10/2024]
+
+#### Removed:
+-*store-locator*:
+  - Removed radius selector and changed default radius to 50km
+  - Removed radiusOption attribute
+
+#### Updated:
+-*store-locator*:
+  - Now opens the list of stores directly in webmobile after searching by address or geolocation
+  - Now shows the home delivery stores in first position
+
+## 0.6.0 [31/10/2024]
+
+#### Updated:
+- *catalog*:
+  - created catalog.css for shared styles between catalog components
+
+#### Fixed:
+- *like-button*:
+  - State of button was not updated properly
+
+## 0.5.0 [03/10/2024]
+
+#### Added:
+- *store-locator*:
+  - Added loaders on the POS select buttons after selecting a POS
+  - Added searchChange output
+- *catalog-category*
+  - Added component
+- *catalog-favorites*
+  - Added component
+- *catalog-breadcrumbs*
+  - Added component
+- *catalog-toolbar*
+  - Added component
+
+#### Fixed:
+- *like-button*
+  - now listens to recipe-like changes
+
+## 0.4.0 [20/09/2024]
+
+#### Added:
+- *catalog-category-home*:
+  - Added component with its hydration and lifecycle 
+- *recipe-pricing*
+  - Added fetch on scroll
+
+#### Fixed:
+- *recipe-card-cta*
+  - Fixed state didn't update correctly
+
+## 0.3.0 [20/09/2024]
+
+**All components except store-locator are now the hydration & lifecycle of the corresponding HTML returned by the routes from Mealz SSR API**
+**The components lifecycle use webc-miam@9.0 via the interface window.mealzInternal**
+
+#### Added:
+- *store-locator*:
+  - Added supplierName property to posIdChange event
+- *recipe-card*:
+  - Added component with its hydration and lifecycle
+- *recipe-card-cta*:
+  - Added component with its hydration and lifecycle
+- *recipe-pricing*:
+  - Added component with its hydration and lifecycle
+- *like-button*:
+  - Added component with its hydration and lifecycle
+
+
+## 0.3.0-alpha.1 - [17/07/2024]
+#### Fixed:
+- put "vite-plugin-static-copy" package at right place
+
+#### Updated:
+- gitlab-ci now build like-button and recipe-card
+
+## 0.3.0-alpha.0 - [17/07/2024]
+
+#### Added:
+- *like-button*:
+  - component first commit
+- *recipe-card*:
+  - component first commit
+
+## 0.2.1 - [16/07/2024]
+
+#### Fixed:
+- *store-locator*:
+  - Fixed nested CSS doesn't work for tag names
+
+## 0.2.0 - [16/07/2024]
+
+#### Added:
+- *store-locator*:
+  - When loading POS, displays a loader in the pos list
+  - No POS found indicator
+  - New radius selector for POS search
+  - New supplier selector to filter results
+  - Can now submit search using keyboard (Android / iOS / Web)
+
+#### Fixed:
+- *store-locator*:
+  - Updated the search radius default value from 10 km to 25 km.
+  - geolocationCoordinates input type changed to GeolocationPosition (was a custom Coordinates interface before)
+  - Map initialization now waits for Leaflet to be fully loaded
+  - Adjusted CSS for store-locator mobile view
+
+## 0.1.2
+
+#### Added
+- *store-locator*:
+  - Geolocation
+
+## 0.1.1
+
+#### Added
+- *store-locator*:
+  - Added some css classes to scope on elements
+  - Added miam-ds to component
+
+## 0.1.0
+
+#### Added
+- *store-locator* component
+
+#### Internal
+- Added a demo page to display the store-locator

--- a/docs/web_ssr/changelog/changelog-nest.md
+++ b/docs/web_ssr/changelog/changelog-nest.md
@@ -4,6 +4,77 @@ sidebar_position: 1
 
 # Mealz SSR API Changelog
 
+## 2.8.0 [26/03/2026]
+
+#### Added
+- *my-space* - v1 & v2
+  - Added container div with a class name .mealz-my-space around the content of the page to make it more coherent with the other pages and facilitate page-specific style overriding 
+  - Added classes names .mealz-tab-favorites and .mealz-tab-history on the tabs (className .mealz-catalog-tabs__item) so the tab icons can overriden individually
+
+#### Updated
+- *recipe-card* - v2
+  - Recipe card `display_variant` (1–4) is normalized on the API and applied in SSR (`recipe-card.ejs`): badge and bottom like-button layout match legacy Angular behavior; `POST /recipe-card/multiple` no longer forces badge/like flags off.
+
+#### Internal
+- *catalog-toolbar* & *breadcrumb* - v1 | v2
+  - Replaced raw string page comparisons with `Pages` enum (v2) and `CatalogPages`/`Pages` (v1 toolbar) for consistent page detection across catalog views.
+  - v1 catalog-toolbar: supports v1 `CatalogPages` enum values.
+  - v2 catalog-toolbar: uses `Pages.CATALOG_*` for home, favorites, my-space, and history tab logic.
+  - v2 breadcrumb: uses `Pages` enum keys in page titles map instead of raw strings.
+  - v1 catalog-home: fixed page value to `Pages.CATALOG_HOME`.
+  - Update mealz-component version to 2.7.1
+
+## 2.7.0 [19/03/2026]
+
+#### Added
+- *catalog/my-space* - v2
+  - New query param `show_tab_selector` to toggle the segmented control (Favoris/Historique tabs). When `false` or `0`, tabs are hidden and the page title shows the active section ("Favoris" or "Historique") instead of "Mon carnet".
+- *basket-preview* - v2
+  - New route `GET /v2/catalog/my-space/basket-preview` to render basket preview standalone (title, show_tab_selector, embed query params).
+  - New EJS template `basket-preview.controller.ejs` with drawer-view-swapper and init-basket-preview-drawer scripts for direct navigation.
+
+#### Removed
+- *catalog-favorites* - v2
+  - Removed standalone catalog-favorites page route (`GET /v2/catalog/favorites`) was not used. Favorites are only available via my-space (`/v2/catalog/my-space`). v1 catalog-favorites remains unchanged.
+
+#### Updated
+- *baskets-service* - v2
+  - Handle 400 response with "Inexistant record for point_of_sale_id" gracefully: return empty basket instead of throwing.
+- *my-space-service* - v2
+  - Added readonly to constructor dependencies.
+- *planner-menu-option* - v2
+  - Custom menu recipe avatars: when more than 6 recipes, show 5 avatars plus an overflow badge (+N) instead of empty plate placeholders.
+- *catalog* - Implemented versioned endpoints for catalog categories, favorites, and my-space load-more. Routes now use explicit `@Version('1')` / `@Version('2')` and call the corresponding v1/v2 services.
+- *packages* - v1: `getPackageById` now unwraps `response.data` and returns the package object directly; throws `NotFoundException` instead of `BadRequestException` when the API returns no data (aligned with v2 semantics).
+- *no-supplier-add-to-cart-cta* - v2
+  - `recipe_id` query param is now treated as external recipe ID: the service resolves it to the internal recipe ID via `RecipesService.getRecipeByExtId` before checking basket status. Falls back to the provided value when no match is found.
+- *recipes* - v2
+  - Added `getRecipeByExtId(headers, recipeExtId)` to fetch recipe by external ID (cached 5s, returns null when not found).
+
+
+#### Internal
+- Refactored catalog controllers to use version-specific service instances (CatalogCategoryServiceV1/V2, etc.) instead of runtime version detection for load-more routes.
+- *demo*
+  - Added basket preview to custom-elements demo page.
+- *no-supplier-add-to-cart-cta* - v2
+  - Added unit tests for NoSupplierAddToCartCtaService.
+- Update mealz-components to 2.7.0 and SDK to 10.4.0
+
+## 2.6.3 [03/03/2026]
+
+#### Updated
+- *planner* - v2
+  - When fetching the current menu, if the selected store differs from the menu `point-of-sale-id`, the menu is patched to match the selected store to keep planner data consistent.
+  - Removed deprecated planner entrypoints and links: dashboard page (`GET /planner` legacy), `GET /planner-card-link`, `GET /planner-banner-link`. The planner landing endpoint now renders the current menu experience (`planner-current-menu`).
+  - Updated routing configuration: removed `planner.dashboard`; planner routing now relies on `planner.current` only.
+
+#### Fixed
+- *recipes* - v2
+  - `hasPromotions()` now returns `false` when `storeId` is missing, allowing planner screens to work without a selected POS.
+- *recipe-pricing* - v2
+  - Pricing wrapper is only displayed when `price-per-serve` exists, preventing empty pricing blocks.
+
+
 ## 2.6.2 [26/02/2026]
 
 #### Fixed
@@ -33,7 +104,7 @@ sidebar_position: 1
   - Added drawer stylesheets to recipe-card
   - Added recipe-details and like button stylesheets to recipe-card-cta
 - *planner-entry*
-  - Replaced minus and plus icon in the stepper with `<img>` to replace easily for suppliers overrides
+  - Replaced minus and plus icon in the stepper with <img> to replace easily for suppliers overrides
 - *recipe-card-cta*
   - Added the parameter `to_basket_on_click` that is provided in the starting data
 - *planner-budget-gauge* - v2
@@ -270,6 +341,9 @@ sidebar_position: 1
   - Add ANALYTICS_URL environment variable for analytics endpoint configuration
   - Add ANALYTICS_ENABLED environment variable for development environment
 
+#### Internal:
+- Added add-to-cart CTA to demo
+
 ## 2.0.0-beta.5 [09/10/2025]
 
 #### Added:
@@ -404,143 +478,638 @@ Upgraded from `miam-ds@1.2.6` to `mealz-ds@2.0.0`. The design system was renamed
 - *searchbar*:
   - Fix searchbar placeholder on favorite page
 
-## Upgrading from v1
+## 1.3.20 - [23/10/2025]
 
-This guide outlines the breaking changes and migration steps when upgrading from v1 to v2.
+#### Internal
+- *analytics-service*
+  - Send events to bigQuery instead Plausible
+  - Add ANALYTICS_URL environment variable for analytics endpoint configuration
+  - Add ANALYTICS_ENABLED environment variable for development environment
+  - Analytics can now be disabled in development mode by setting ANALYTICS_ENABLED=false
+  - UAT and PROD environments always send analytics regardless of ANALYTICS_ENABLED setting
 
-### Removed Configuration
+## 1.3.19 - [16/10/2025]
 
-The following configuration has been removed:
-- `mealz.features.enableGuestsInputOnMyMeals()`
-- `mealz.features.enableArticlesInCatalog()`
+#### Config
+- Update version for mealz-components 1.3.13
 
-### Updated Configuration
+## 1.3.18 - [13/10/2025]
 
-The following configuration has been updated:
-- `mealz.basketSync.defineRemoveProductsFromCart()`: The callback is now called with products with positive quantities
+#### Internal
+- *cache-service*
+  - UserID is now optional in cache key.
+- *pos-service*
+  - Updated pos service to remove userID from cache key usage.
+- **Logging System**:
+  - Implemented logger with Google Cloud Logging integration
+  - Added distributed tracing support using AsyncLocalStorage
 
-### Component Renaming
 
-#### Prefix Changes
+## 1.3.17 - [25/09/2025]
 
-All components previously using `ng-miam-*` and `webc-miam-*` prefixes have been renamed to use the `mealz-*` prefix. Additionally, all CSS class names with `miam-...` have been updated to `mealz-...`.
+#### Added
+- *recipe-card*
+  - Added "keyword" body attribute to /multiple route 
 
-<details>
-<summary>Components with updated prefixes</summary>
+#### Config:
+  - Update version for SDK to 9.1.21
 
-- `ng-miam-no-pos-selected` → `mealz-no-pos-selected`
-- `ng-miam-products-picker` → `mealz-products-picker`
-- `ng-miam-slider-tabs` → `mealz-slider-tabs`
-- `ng-miam-replace-item` → `mealz-replace-item`
-- `webc-miam-basket-transfer-modal` → `mealz-basket-transfer-modal`
-- `webc-miam-last-order-modal` → `mealz-last-order-modal`
-- `webc-miam-no-supplier-onboarding` → `mealz-no-supplier-onboarding`// TODO Has been removed in v2 ?
-- `webc-miam-recipe-addon` → `mealz-recipe-addon`
-- `webc-miam-recipe-details` → `mealz-recipe-details`
+## 1.3.16 - [03/09/2025]
 
-</details>
+#### Fixed:
+- *recipe-card*
+  - Changed NotFoundException throws to return null or empty arrays when no recipe suggestions found
 
-#### Name Changes
+## 1.3.15 - [26/08/2025]
 
-The following components have been renamed with new naming conventions:
+#### Added
+  - *recipe-card*
+    - Added "categoryId" body attribute in /multiple route
 
-- `ng-miam-progress-tracker` → `mealz-planner-budget-gauge`
-- `ng-miam-store-locator` → `mealz-store-locator-drawer`
-- `webc-miam-recipe-details-infos` → `mealz-details-infos`
-- `webc-miam-recipe-details-ingredients` → `mealz-details-ingredients`
-- `webc-miam-recipe-details-steps` → `mealz-details-steps`
-- `webc-miam-recipe-modal` → `mealz-drawer-view-swapper`
-- `webc-miam-store-locator-link` → `mealz-store-indicator`
-- `mealz-catalog-breadcrumb` → `mealz-breadcrumb`
+#### Fixed:
+- *catalog-list*
+  - Fix button preferences displayed on search results despite configuration to turn them off
 
-### Sponsor Components Consolidation
+#### Config:
+  - Update version for mealz-component to 1.3.12
+  - Update versions for local and UAT
 
-All sponsor-related components have been deprecated and replaced by a single, unified component: `mealz-sponsor-block`
+## 1.3.14 - [06/08/2025]
 
-> **Note:** The internal CSS classes for sponsor components remain unchanged.
+#### Config:
+- Update component version 1.3.11 in env
 
-<details>
-<summary>Deprecated sponsor components</summary>
+## 1.3.13 - [04/08/2025]
 
-- `ng-miam-sponsor-block-container`
-- `ng-miam-sponsor-image-and-text-block`
-- `ng-miam-sponsor-image-with-text-block`
-- `ng-miam-sponsor-logo-block`
-- `ng-miam-sponsor-picture-block`
-- `ng-miam-sponsor-small-picture-block`
-- `ng-miam-sponsor-small-text-block`
-- `ng-miam-sponsor-small-title-block`
-- `ng-miam-sponsor-text-and-image-block`
-- `ng-miam-sponsor-text-block`
-- `ng-miam-sponsor-title-block`
+#### Fixed:
+- *recipe-card*:
+  - Fix pricing flickering with loader
 
-</details>
+#### Config:
+- Update component versions in env
 
-### Removed Components
+## 1.3.12 - [04/08/2025]
 
-#### Unused Components
+#### Config:
+- Update component versions in env
 
-The following components were removed due to lack of usage:
+## 1.3.11 - [04/08/2025]
 
-- `ng-miam-tabs`
-- `ng-miam-time-picker`
-- `ng-miam-toaster`
-- `webc-miam-toaster-stack`
+#### Fixed : 
+- *recipe-card*:
+  - Revert usage of store ext id in route multiple
 
-#### Deprecated Components
+## 1.3.10 - [04/08/2025]
 
-These components have been fully removed as they are deprecated and no longer maintained:
+#### Updated:
+- *recipe-card*:
+  - Optimized /multiple route performance by moving dynamic data fetching to client-side
+  - Removed server-side API calls for likes, pricing, and basket data
+  - Simplified data formatting and reduced parallel API calls
 
-<details>
-<summary>List of deprecated components</summary>
+## 1.3.9 [24/06/2025]
 
-- `ng-miam-addon-link`
-- `ng-miam-guests-dropdown`
-- `ng-miam-meals-planner-basket-confirmation`
-- `ng-miam-meals-planner-basket-preview`
-- `ng-miam-meals-planner-catalog`
-- `ng-miam-meals-planner-form`
-- `ng-miam-meals-planner-result`
-- `ng-miam-tooltipable-content`
-- `webc-miam-basket-preview-block`
-- `webc-miam-basket-preview-disabled`
-- `webc-miam-basket-preview-line`
-- `webc-miam-meals-planner`
-- `webc-miam-recipes-history`
-- `webc-miam-sponsor-storytelling`
-- `webc-miam-warning-store-locator`
+### Fixed:
+- *recipe-card-cta*
+  - Fix displaying CTA when shouldRemovePersonalization is true
 
-</details>
+## 1.3.8 [23/06/2025]
 
-:::warning
-If any of your style overriding or other interactions includes components listed above, please update them accordingly.
-:::
+#### Config:
+- Update SDK / Component versions in env
 
-### Drawer Components Structure
+## 1.3.7 [23/06/2025]
 
-All drawer and modal components have been restructured to use a consistent pattern:
+#### Fixed:
+- *demo/retailer-cart*:
+  - Optimized cart updates by only triggering the retailerBasketChanged event once after adding multiple products instead of after each individual product
+- *recipe-card*:
+  - Fixed recipe card basket detection when using suggested recipes, ensuring correct guest count is displayed for recipe cards loaded via product suggestions
 
-```html
-<mealz-drawer>
-  <mealz-drawer-view-swapper>
-    <MEALZ_COMPONENT></MEALZ_COMPONENT>
-  </mealz-drawer-view-swapper>
-</mealz-drawer>
-```
+#### Deleted:
+- *pricebookKey*:
+  - Remove deprecated variable pricebookKey
 
-This new structure applies to:
-- `basket-preview`
-- `history-drawer`
-- `recipe-addon`
-- `recipe-details`
-- `replace-item`
-- `preferences`
+## 1.3.6 [16/06/2025]
 
-### Design System Renaming
+#### Fixed:
+- *recipe-card*:
+  - Fixed issue where all recipe cards in multiple route used the same guest count instead of respecting individual recipe guest settings
+- *recipe-pricing*:
+  - Fixed issue where recipe cards in catalog home beyond the first two categories used a hardcoded guest count of 4 instead of the recipe's actual guest count
 
-Our design system has been renamed from `miam-ds` to `mealz-ds`. All style classes previously using `miam-ds-...` have been updated to `mealz-ds-...`.
 
-#### CSS Custom Properties
+## 1.3.4 [10/06/2025]
 
-All CSS custom properties previously using the `--miam-*` prefix have been renamed to use the `--mealz-*` prefix.  
-If you override design system tokens in your own styles (e.g. in `:root` or retailer-specific styles), update any `--miam-*` variables to their `--mealz-*` equivalents.
+#### Fixed:
+- *recipe-pricing*:
+  - Revert previous changes
+
+## 1.3.3 [10/06/2025]
+
+#### Updated:
+- If render if called and price is defined, update the view
+
+## 1.3.2 [06/06/2025]
+
+#### Fixed:
+- *catalog*:
+  - All /load-more routes were missing `shouldRemovePersonalization: false` 
+
+## 1.3.1 [06/06/2025]
+
+#### Added:
+- *styles*:
+  - Added `/styles/catalog/my-space` which corresponds to the styles for the `/my-space` route. It combines the previous routes `/styles/catalog/catalog-history` & `/styles/catalog/catalog-favorites`
+
+#### Updated:
+- *recipe-card*:
+  - Added a global configuration in supplier-tokens to disable personalization in both recipe-card routes. When disabled, the pre-rendered recipes-cards will not display the like button nor the cart CTA at prerender, and both will be displayed client-side, to avoid issues with caching between users.
+  - /multiple route now uses the new suggestion-batch route from miam-api for better performances
+- *preferences*:
+  - Preferences are disabled if personalization is disabled, meaning the button will not be rendered and if the user had any preferences set, they are removed
+
+#### Fixed:
+- *recipe-card*
+  - The /multiple route now returns a JSON array of the recipe cards instead of one HTML
+- *my-space*:
+  - Added missing paths in startingData for favorites & history
+
+## 1.3.0 [23/05/2025]
+
+#### Updated:
+- *my-space*:
+  - History now has a toggle to switch the view style between 'grid' and 'list' mode
+  - Added a new param `history_style` to the /my-space route. The param only has an effect when used alongside `tab=history` and can have as value either 'grid' or 'list', defaulting to 'grid' of not passed.
+  - Using the new view style toggle will put in the currentUrl either `&history_style=grid` or `&history_style=list`, which can be passed to the /my-space route
+
+## 1.2.26 [19/05/2025]
+
+#### Internal:
+- Update CI to push to artifact registry
+- Added 2 more cards on shelf demo page
+- Fixed potential error on demo if there was not enough product to display cards
+
+## 1.2.25 [05/05/2025]
+
+- Removed @google-cloud/logging which had performance issues and replaced with correctly formatted console.log
+
+## 1.2.24 [02/05/2025]
+
+- Revert previous tag for performances reasons
+
+## 1.2.23 [02/05/2025]
+
+#### Internal:
+- upgraded Nest to v11
+- Added @google-cloud/logging library for better logging on GCP
+- Added new Logger service to log for GCP in uat & prod and use default Logger only for dev
+- Updated fetch to node-fetch to have the option to log response headers with response.entries()
+
+# 1.2.22 [29/04/2025]
+
+#### Fixed:
+- Handle-payment doesn't confirms the basket twice if called twice in a row
+- Added headers to the plausible calls just in case they weren't automatically passed
+
+## 1.2.21 [23/04/2025]
+
+Updated to webc-miam@9.1.15
+Updated to mealz-components@1.2.8
+
+## 1.2.20 [23/04/2025]
+
+#### Updated:
+- handle-payment route now checks the order-id param if passed to not confirm different baskets for the same order
+
+#### Internal:
+- Added more logs for plausible events in order to check if they are sent correctly
+
+## 1.2.19 [22/04/2025]
+
+#### Fixed:
+- Added url attribute in the body of requests sent to plausible, as its absence caused these requests to return a 400 error
+
+## 1.2.18 [22/04/2025]
+
+#### Internal:
+- Added more logs for headers checks on all routes
+
+## 1.2.17 [18/04/2025]
+
+Updated to mealz-components@1.2.7
+
+## 1.2.16 [18/04/2025]
+
+Updated to webc-miam@9.1.14
+Updated to mealz-components@1.2.6
+Updated to miam-ds@1.2.6
+
+#### Fixed:
+- *toolbar*: anchor was missing a navigate back
+
+#### Internal:
+- *supplier-values*:
+    - Added Marmiton default values for the env-configurator
+- *recipe-card*:
+  - Added an id on the format "mealz-recipe-card-{RECIPE-ID}"
+
+## 1.2.15 [14/04/2025]
+
+Updated to webc-miam@9.1.13
+
+## 1.2.14 [04/04/2025]
+
+Updated to webc-miam@9.1.12
+
+## 1.2.13 [03/04/2025]
+
+#### Fixed:
+- Resolved issue where recipe details always opened with 4 guests by refining guest count logic in : *catalog-category*, *catalog-favorites*, *catalog-home*, *catalog-list*, *my-space*
+- *catalog-home*:
+  - Did not have an empty state for extreme cases of contradictory preferences
+
+#### Internal:
+- Removed unused `serves` query param in load-more functionality for: *catalog-category*, *catalog-favorites*, *catalog-list*, *my-space*
+
+## 1.2.12 [31/03/2025]
+
+#### Internal:
+- Changed all urls from unpkg to cdn.jsdelivr/npm to avoid unpkg that was down on 31/03/2025
+
+## 1.2.11 [28/03/2025]
+
+#### Fixed:
+- *catalog-favorites*:
+  - Fixed init state was incorrect
+
+#### Internal:
+- Fixed log in case of missing auth headers
+
+## 1.2.10 [26/03/2025]
+
+#### Fixed:
+- Updated to webc-miam@9.1.8 to fix bug on basket-preview opening the last added recipes instead of the one clicked in some cases
+- miam-api prod URL had an unnecessary "/"
+
+## 1.2.9 [24/03/2025]
+
+#### Fixed:
+- *recipe-card*:
+  - Optimized performances for the /recipe-card route: Should reduce response times by 150 to 200ms
+
+## 1.2.8 [21/03/2025]
+
+#### Fixed:
+- Better logging for supplier-token errors
+- *catalog-routing*:
+  - Added redirecting url for my-space for the catalog-routing config for supplier 23
+- *catalog-toolbar*:
+  - Removed href for the back button as now the component does a native back action client-side
+- *recipe-card*:
+  - Optimized performances for the /recipe-card/multiple route: Should reduce response times by 150 to 200ms
+
+#### Internal:
+- Fixed coverage rules to be at 100%
+- Gave access in the starting data of `recipe-pricing` if the recipe is already in the basket
+
+## 1.2.7 [07/03/2025]
+
+#### Updated:
+- Added automatic completion filters for all routes returning recipe-cards - recipes without their primary ingredient available in the store will not appear anymore
+
+#### Fixed:
+- Fixed null error when store_id was not provided for all routes returning recipe-cards
+
+## 1.2.6 [28/02/2025]
+
+#### Internal:
+- Added unit tests to all services
+- *git-hooks*:
+  - Added a pre-push hook that runs tests before pushing anything upstream
+- *demo-app*:
+  - retailer-cart: Added basket sync on demo start up as first basket change call is dedicated to sync
+  - Fixed generate-authless route call asking for headers
+- *catalog-category*
+  - Added analytics path to starting-data so mealz-components can send pageview event
+- *catalog-favorites*
+  - Added analytics path to starting-data so mealz-components can send pageview event
+- *retailer-cart*:
+  - Added basket sync on demo start up as first basket change call is dedicated to sync
+## 1.2.5 [21/02/2025]
+
+#### Fixed:
+- *handle-payment*:
+  - Fixed possible concurrency errors and undefined errors
+  - Does not try to confirm an empty basket
+  - Correctly sends the analytics events 
+
+## 1.2.4 [07/01/2025]
+
+#### Added:
+- *recipe-card*:
+  - Added a new route /recipe-card/multiple to fetch more than one card at once. It takes an array of surrounding_products_ids as input and returns a HTML of all cards
+
+## 1.2.3 [31/01/2025]
+
+#### Internal:
+- *catalog-category*
+  - Added analytics path to starting-data so mealz-components can send pageview event
+- *catalog-favorites*
+  - Added analytics path to starting-data so mealz-components can send pageview event
+- *retailer-cart*:
+  - Added basket sync on demo start up as first basket change call is dedicated to sync
+
+## 1.2.2 [17/01/2025]
+
+#### Fixed:
+- *recipes*:
+  - Fixed number of guests for recipes in the basket, ensuring the number of guests remains as it was when the recipe was added to the basket
+- *recipe-card*
+  - Fixed JSON parsing error for surroundingProductsIds by adding a try-catch block
+  - Prevent null reference errors when accessing recipe pricing data
+- *recipe-pricing*
+  - Load discounted ingredients count when the recipe is already in the basket
+
+#### Internal:
+- Added a new page to the demo simulate a retailer cart and interactions with the products (add, update, remove)
+
+## 1.2.1 [10/01/2025]
+
+#### Updated:
+- *recipe-card*:
+  - Added the attribute aria-hidden="true" to recipe picture as redundant with recipe label
+
+#### Fixed:
+- Fixed CORS configuration to allow all localhost origins, removing the restriction to only port 4200
+- *recipe-card*:
+  - Favorite button was still displayed when user was not logged
+
+## Internal:
+- *recipes*
+  - Updated `page_size` and `page_number`search request params
+- *catalog-home*
+  - Added `sessionId` to starting-data to synchronize session id with SDK
+- *recipe-card*
+    - Added `sessionId` to starting-data to synchronize session id with SDK
+- *catalog-home*:
+  - Added analytics path & category id to starting-data so mealz-components can send category.display event
+
+## 1.2.0 [20/12/2024]
+
+### Added:
+- *catalog-history*
+  - Added component + controller for JS injection
+  - Added search functionality
+  - Added "no history" view
+- *catalog-tabs*
+  - Added tabs for Favorites / History
+- *drawer*
+  - Added component
+- *history-order*
+  - Added component
+- *recipe-card*
+  - Added a variant
+- *http.service*
+  - Added `profiling` as an optional header for all routes, defaulting to `true`
+  - Added `profiling=off` query param in all requests to `miam-api` when the profiling header value is "false"
+
+#### Updated:
+- All features now have semantic tags (p, h1, h2, h3, h4) instead of div and spans around texts
+- *recipe-card*
+  - Removed the `profiling` query param from the `recipe-card` route
+- *recipe-pricing*
+  - Removed the `profiling` query param from the `recipe-pricing` route
+- *catalog-toolbar*
+  - Renamed the favorites button to my space
+
+#### Fixed:
+- baskets/handle-payment route now takes as body the current retailer car in order to sync the basket with the cart before confirming it
+
+#### Internal:
+- Added a first basic implementation of JSONAPI data management with generic interfaces, a generic fetchAll method and models for the BasketEntries and Items.
+- *analytics*:
+  - Add `path` to recipe-card starting-data
+  - Add myMealsButtonStartingData with `path`
+  - New AnalyticsPaths enum
+- *auth-widget*:
+  - New component to handle user log status handled by cookies
+- *headers*:
+  - Added new `authless-id` attribute in header
+  - `authless-id` header is turned into authorization header for miam-api
+  - New component in demo app to handle user log status handled by cookies
+
+## 1.1.2 [29/11/2024]
+
+#### Added:
+- *basket*
+  - Added a controller and methods to handle merge authless basket
+  - Added a controller and methods to handle payment confirmation
+
+#### Added:
+- *promotions-banner*:
+  - New promotions-banner component on catalog home
+- *recipe-promotion-badge*:
+  - New recipe-promotion-badge component currently displayed on recipe cards
+
+#### Fixed:
+- catalog-routing always used the dev routing file
+- *styles*:
+  - Added missing breadcrumb style on catalog-category style route
+
+## 1.1.1 [22/11/2024]
+
+#### Added:
+- *catalog-favorites*
+  - Added a controller to load more recipe cards
+- *catalog-list*
+  - Added a controller to load more recipe cards
+- *catalog-toolbar*
+  - Added preferences loader
+- *recipe*
+  - Added recipe model
+- *sponsor*
+  - Added sponsor model
+
+#### Updated:
+- *catalog-category*
+  - Updated the url from `/category?id=[category_id]` to `/category/[category-name-slug]/[category_id]`
+
+#### Updated:
+- Updated allowed origins to support additional trusted domains
+
+#### Fixed:
+- *CORS*
+  - Added support for the OPTIONS method
+- *recipes.service*
+  - Added validation for JSON response to avoid parsing errors
+  - Refactored `getRecipeSponsorLogoUrl` to use `Recipe` model methods instead of nested properties
+
+#### Internal:
+- Updated several dependencies to newer, more secure versions
+- *slug.service*
+  - Added a service to convert text to slug
+- *recipes.service*
+  - Updated the search endpoint path from `/recipes?search=[search]` to `recipes/search?name=[search]`
+
+## 1.1.0 [15/11/2024]
+
+#### Added:
+- Added `mealz-session-id` to request headers
+- Added Redis configuration for caching
+- *catalog-category*
+  - Implemented empty state for scenarios where no recipes match the selected criterias.
+  - Added search functionality
+  - Integrated user preferences
+- *catalog-favorites*
+  - Added search functionality
+- *catalog-home*
+  - Integrated user preferences
+- *catalog-list*
+  - Added component + controller for JS injection
+- *catalog-toolbar*
+  - Added preferences badge count
+
+#### Updated:
+- *catalog-toolbar*
+  - Removed unused filters
+- *catalog-favorites*
+  - Removed preferences button
+
+#### Internal:
+- Added a cache controller to manage Redis cache through ng-miam-sdk
+- Enabled caching for `getBasket`, `getPointOfSaleByExtId`, `getByRecipeId`, `getRecipeById`, `getRecipePricing`
+
+#### Fixed:
+- *catalog-home*:
+  - Added back arrow to "See All" button.
+- *generate-authless-token*
+  - Added error handling for missing or invalid supplier token
+- *http.service*
+  - Added null checks for supplier data to avoid errors when supplierId is undefined or null
+- *point-of-sales.service*
+  - Added a check to ensure `pos` is defined before attempting to access `id`
+
+## 1.0.2 [08/11/2024]
+
+#### Added:
+- Added logs for missing required query parameters
+
+#### Fixed:
+- *catalog*:
+  - Made the *display_recipe_variant* query paramater optional
+
+## 1.0.1 [04/11/2024]
+
+#### Updated:
+- *urls*:
+  - Moved every routes from v0 to v1
+
+#### Fixed:
+- *recipe-card*
+  - Fixed suggested recipe-card
+
+## 1.0.0 [24/10/2024]
+
+#### Breaking changes:
+- *window.miam*:
+  - Renamed to window.mealz
+
+#### Added:
+- *catalog-category*
+  - Added component + controller for JS injection
+- *catalog-favorites*
+  - Added component + controller for JS injection
+- *catalog-home*
+  - Added controller for JS injection
+- *like-button*
+  - Added controller for JS injection
+- *recipe-card*
+  - Added controller for JS injection
+- *recipe-card-cta*
+  - Added controller for JS injection
+- *recipe-pricing*
+  - Added controller for JS injection
+- *catalog-breadcrumbs*
+  - Added component
+- *catalog-toolbar*
+  - Added component
+- *my-meals-button*
+  - Added component
+    -*http.service*
+- Now handles errors and build header from this service, throw error when category_id is required but not provided
+
+#### Updated:
+- *catalog*:
+  - Now fetches recipe sponsor on catalogs pages
+- *catalog-category*:
+  - update routes from /catalog/category/ID to /catalog/category?id=ID
+- *recipe-card*:
+  - if no suggestion is given for recipe in shelf, throws NotFoundException
+- *ng-miam-sdk*:
+  - updated to 9.0.1 on prod and uat
+
+#### Fixed:
+- *catalog-favorites*:
+  - Fix new logic on like button
+
+## 0.2.1 [23/09/2024]
+
+#### Fixed:
+- *recipe-card*:
+  - Fixed double basket-current call
+
+#### Internal:
+- Added performance log to measure requests times
+
+## 0.2.0 [20/09/2024]
+
+#### Added:
+- *point-of-sales-service*:
+  - Added point-of-sales service with method getPointOfSaleByExtId
+- *nextJS-demo*:
+  - Added NextJS Demo to project using the SSR API
+- *catalog*:
+  - Initiated recipe catalog with home page
+- *styles*:
+  - Added routes to fetch components styles individually to add them to `<head>`
+- *i18n*:
+  - Added I18n for catalog-home, my-meals-button, recipe-pricing and recipe-card-cta
+
+#### Fixed:
+- *recipe-pricing*:
+  - Recipe pricing initial data was an object rather than a string with the value
+
+#### Internal:
+- Updated mealz-component version to 0.4.0
+- Added Nest built-in logger to project with some errors handling
+
+## 0.1.1 [03/09/2024]
+
+#### Fixed:
+- env config for uat & prod
+
+## 0.1.0 [30/08/2024]
+
+#### Added
+- *like-button*:
+  - Added a route for the component, and the associated services and views
+- *recipe-card*:
+  - Added a route for the component, and the associated services and views
+- *recipe-pricing*:
+  - Added a route for the component, and the associated services and views
+- *i18n*:
+  - POC of i18n implementation, not enough text in the served components to use yet
+- *routes*
+  - Added a generate-authless-token route to fetch an authless token for loggued out users
+- *versioning*:
+  - Added basic versioning handler on url
+
+#### Internal
+- Added baskets service
+- Added recipes service
+- Added recipe-likes service
+- Added supplier service
+- Added user service
+- Added scripts to download SDK Web-C lib and style files to each components
+- Added environment files for dev, uat and prod

--- a/web_ssr_versioned_docs/version-v1/changelog/changelog-lit.md
+++ b/web_ssr_versioned_docs/version-v1/changelog/changelog-lit.md
@@ -107,8 +107,70 @@ sidebar_position: 2
 ## 1.3.0 [23/05/2025]
 
 #### Added:
+- *basket-preview*:
+  - Added component with interactions
+  - Added component noSupplier mode
+  - Added products view which can be hidden through supplierToken
+  - product views has number of recipes badge and clicking on it shows a modal with the recipe name list
+- *counter*:
+  - Created component
+- *basket-preview-product*:
+  - Created component
+- *mealz-modal*:
+  - Created component
+- *recipe-details*
+  - Added component
+- *skeleton*:
+  - Added CSS class mealz-skeleton-loader that can be imported when needed
+- *store-locator-drawer*
+  - Added component with interactions
 - *history-order-expanded*:
   - Added new component for the new history display in list mode
+
+#### Updated:
+- *CSS*:
+  - Replaced every color fallbacks occurrence with new colors from miam-ds
+- *drawer*:
+  - Component is now called through HTML tags and content is now passed through HTML slots
+- *no-shadow-element*:
+  - updated styleURL to be an array of URLs or a single URL and update boilerplate to handle it
+- *config*:
+  - Added styles folder to the build input
+- *basket-preview-product*:
+  - Replace basketEntryId property with basketEntry preventing stale data 
+- *slider-tabs*:
+  - Slider now updates visually when selectedTabIndex is changed from parent
+
+#### Internal:
+- *history-drawer*:
+  - The component now uses `drawer-view-swapper`
+- *recipe-addon*:
+  - Added component with interactions
+- *store-indicator*:
+    - Added component with interactions
+- *slider-tabs*:
+    - Added component with inputs / outputs
+- *sponsor-block*:
+  - Added component
+- *utils*:
+    - Add round, capitalize and stopPropagation functions
+- *models*:
+    - Add BasketEntry model
+- *product-addition*:
+  - Added component with interactions
+- *no-shadow-element*:
+  - Add `addStyles` and `removeStyles` boilerplate
+- *price*:
+  - Created component
+- *lang-to-currency*:
+  - Created a map to assign a currency to a language
+- *miam-ds*
+  - Turned miam colors into design system colors
+- *types*:
+  - Add Recipe definition
+  - Add Ingredient definition
+- *vite.config*
+  - Exclude files from build to minimize calls
 
 #### Fixed:
 - *history-order*:
@@ -120,7 +182,7 @@ sidebar_position: 2
 #### Fixed:
 - *my-meals-button*:
   - The arrow could come out of the button of mobile resolutions
-- Removed remaining occurences of miam-ds links as to not have conflicts with the version served by SSR-API
+- Removed remaning occurences of miam-ds links as to not have conflicts with the version served by SSR-API
 
 ## 1.2.7 [18/04/2025]
 
@@ -150,7 +212,7 @@ sidebar_position: 2
 #### Fixed:
 - Recipe-cards CSS was lacking the rules to remove margins on p tags that are in the catalog CSS
 - *catalog-load-more*
-  - The auto-load more recipes on scroll was triggered even when no more recipes were available
+  - The auto-load more recipes on scroll was triggered even when no more recipes were available 
 - *catalog-history*:
   - The history-order cards now use a CSS variable for their width that uses the same base value as the recipe-cards by default
 - *catalog-toolbar*:
@@ -202,7 +264,7 @@ sidebar_position: 2
 
 #### Added:
 - *catalog*
-  - Added support for store-locator
+    - Added support for store-locator
 - *recipe-promotion*
   - Added css for component
 - *promotions-banner*
@@ -246,7 +308,7 @@ sidebar_position: 2
 - Fixed margins & selectors after semantic tags were added in SSR-API
 - *catalog-load-more*
   - Catch failed requests and log to console instead of displaying in HTML
-
+  
 #### Internal
 - *recipe-card*
   - Handle `path` and `categoryId` in starting data for analytics
@@ -292,7 +354,7 @@ sidebar_position: 2
 
 #### Added:
 - *catalog*
-- Added support for preferences
+ - Added support for preferences
 
 #### Updated:
 - *catalog-toolbar*
@@ -318,6 +380,30 @@ merged 0.6.1 into 1.0. See 0.6.1 for changes
 #### Breaking changes:
 - *window.miam*:
   - Renamed to window.mealz
+
+## 0.7.0 [10/01/2025]
+
+#### Added:
+- *store-locator*:
+  - Added 3 new events: filterChange with supplierName as detail, mapSelected, listSelected
+
+## 0.6.1 [31/10/2024]
+
+0.6.0 has been unpublished an thus could not be republished.
+
+## 0.6.0 [31/10/2024]
+
+#### Removed:
+-*store-locator*:
+  - Removed radius selector and changed default radius to 50km
+  - Removed radiusOption attribute
+
+#### Updated:
+-*store-locator*:
+  - Now opens the list of stores directly in webmobile after searching by address or geolocation
+  - Now shows the home delivery stores in first position
+
+## 0.6.0 [31/10/2024]
 
 #### Updated:
 - *catalog*:
@@ -350,7 +436,7 @@ merged 0.6.1 into 1.0. See 0.6.1 for changes
 
 #### Added:
 - *catalog-category-home*:
-  - Added component with its hydration and lifecycle
+  - Added component with its hydration and lifecycle 
 - *recipe-pricing*
   - Added fetch on scroll
 
@@ -374,6 +460,7 @@ merged 0.6.1 into 1.0. See 0.6.1 for changes
   - Added component with its hydration and lifecycle
 - *like-button*:
   - Added component with its hydration and lifecycle
+
 
 ## 0.3.0-alpha.1 - [17/07/2024]
 #### Fixed:

--- a/web_ssr_versioned_docs/version-v1/changelog/changelog-nest.md
+++ b/web_ssr_versioned_docs/version-v1/changelog/changelog-nest.md
@@ -166,7 +166,7 @@ sidebar_position: 1
 #### Updated:
 - *my-space*:
   - History now has a toggle to switch the view style between 'grid' and 'list' mode
-  - Added a new param `history_style` to the /my-space route. The param only has an effect when used alongside `tab=history` and can have as value either 'grid' or 'list', defaulting to 'grid' if not passed.
+  - Added a new param `history_style` to the /my-space route. The param only has an effect when used alongside `tab=history` and can have as value either 'grid' or 'list', defaulting to 'grid' of not passed.
   - Using the new view style toggle will put in the currentUrl either `&history_style=grid` or `&history_style=list`, which can be passed to the /my-space route
 
 ## 1.2.26 [19/05/2025]
@@ -238,7 +238,7 @@ Updated to miam-ds@1.2.6
 - *supplier-values*:
     - Added Marmiton default values for the env-configurator
 - *recipe-card*:
-  - Added an id on the format `mealz-recipe-card-{RECIPE-ID}`
+  - Added an id on the format "mealz-recipe-card-{RECIPE-ID}"
 
 ## 1.2.15 [14/04/2025]
 
@@ -328,7 +328,7 @@ Updated to webc-miam@9.1.12
 - *handle-payment*:
   - Fixed possible concurrency errors and undefined errors
   - Does not try to confirm an empty basket
-  - Correctly sends the analytics events
+  - Correctly sends the analytics events 
 
 ## 1.2.4 [07/01/2025]
 
@@ -431,6 +431,12 @@ Updated to webc-miam@9.1.12
 - *basket*
   - Added a controller and methods to handle merge authless basket
   - Added a controller and methods to handle payment confirmation
+
+#### Added:
+- *promotions-banner*:
+  - New promotions-banner component on catalog home
+- *recipe-promotion-badge*:
+  - New recipe-promotion-badge component currently displayed on recipe cards
 
 #### Fixed:
 - catalog-routing always used the dev routing file
@@ -613,17 +619,17 @@ Updated to webc-miam@9.1.12
 
 #### Added
 - *like-button*:
-    - Added a route for the component, and the associated services and views
+  - Added a route for the component, and the associated services and views
 - *recipe-card*:
-    - Added a route for the component, and the associated services and views
+  - Added a route for the component, and the associated services and views
 - *recipe-pricing*:
-    - Added a route for the component, and the associated services and views
+  - Added a route for the component, and the associated services and views
 - *i18n*:
-    - POC of i18n implementation, not enough text in the served components to use yet
+  - POC of i18n implementation, not enough text in the served components to use yet
 - *routes*
-    - Added a generate-authless-token route to fetch an authless token for loggued out users
+  - Added a generate-authless-token route to fetch an authless token for loggued out users
 - *versioning*:
-    - Added basic versioning handler on url
+  - Added basic versioning handler on url
 
 #### Internal
 - Added baskets service


### PR DESCRIPTION
## Summary
Synced changelogs from `mealz-ssr-api` and `mealz-components` into the documentation site.

## Versions added/updated
- **mealz-ssr-api**: **2.8.0**, **2.7.0**, **2.6.3** (and full history aligned with source)
- **mealz-components**: **2.7.1**, **2.7.0** (replaces erroneous Unreleased 2.6.3 block in lit changelog)
- **web_ssr version-v1**: refreshed 1.x sections (`changelog-nest` from 1.3.20, `changelog-lit` from 1.3.15)

## Files
- `docs/web_ssr/changelog/changelog-nest.md`
- `docs/web_ssr/changelog/changelog-lit.md`
- `web_ssr_versioned_docs/version-v1/changelog/changelog-nest.md`
- `web_ssr_versioned_docs/version-v1/changelog/changelog-lit.md`
