### PR TITLE
Refacto: Renamed `meals-planner` to `planner`

### DIFF
--- a/docs/web_ssr/main-features/planner.md
+++ b/docs/web_ssr/main-features/planner.md
@@ -2,11 +2,11 @@
 sidebar_position: 5
 ---
 
-# Meals planner (SSR)
+# Planner (SSR)
 
 ## Overview
 
-The **Meals planner** is a full-page experience that helps users build a meal plan (a “menu”) and then push it to the retailer cart.
+The **Planner** is a full-page experience that helps users build a meal plan (a “menu”) and then push it to the retailer cart.
 
 **The only supported entry point is `planner-entry`**: you embed it on one of your pages (typically the catalog home), and it redirects the user to the planner experience.
 
@@ -29,7 +29,7 @@ The **Meals planner** is a full-page experience that helps users build a meal pl
 
 First-time users are greeted with a quick onboarding modal.
 
-Users can open the onboarding **help modal** at any time to understand (or re-check) how to use the meals planner.
+Users can open the onboarding **help modal** at any time to understand (or re-check) how to use the planner.
 
 - From **`planner-entry`**: the “How it works” / help link opens the modal.
 - From the **current menu page**: the **help button** (question mark / help icon) in the header opens the modal again.
@@ -161,7 +161,7 @@ This is configured in the SSR API routing (example format):
 
 ### Shareable planner URL
 
-Some clients want to use their **planner page URL** in marketing campaigns redirection (example: `https://your-website.com/meals-planner`).
+Some clients want to use their **planner page URL** in marketing campaigns redirection (example: `https://your-website.com/planner`).
 
 The behavior is:
 
@@ -240,4 +240,3 @@ Example planner text keys that can be overridden via i18n:
   },
 }
 ```
-

--- a/docs/web_ssr/set-up-and-usage/basket-synchronization.md
+++ b/docs/web_ssr/set-up-and-usage/basket-synchronization.md
@@ -34,7 +34,7 @@ If the action is not completed after 5 seconds (updated on your cart and in our 
 :::note
 
 The diagram above illustrates the default basket-sync process. However, some use cases differ from it:
-- Actions from basket transfer, authless basket transfer, and the meals planner require us to update our basket first. Then, we send the action list to your cart and, based on the cart you return, adjust our basket accordingly.
+- Actions from basket transfer, authless basket transfer, and the planner require us to update our basket first. Then, we send the action list to your cart and, based on the cart you return, adjust our basket accordingly.
 
 :::
 


### PR DESCRIPTION
Renamed all mentions of "Meals planner" to "Planner", except in the Changelogs

https://app.clickup.com/t/2188392/86ca3z65v