### PR TITLE
Update documentation for custom recipe card analytics

### DIFF
--- a/docs/web_ssr/analytics.mdx
+++ b/docs/web_ssr/analytics.mdx
@@ -32,7 +32,7 @@ See [window.mealz.analytics](./customization/window-mealz#windowmealzanalytics) 
   flexDirection="row-reverse"
 />
 
-For a **custom** recipe card (your own DOM, not the SSR HTML card), you can emit the same `recipe.show` event using `attachRecipeCardShowTracking`; see [Recipe card → Custom recipe card](./main-features/recipe-card#custom-recipe-card-show-tracking).
+For a **custom** recipe card (your own DOM, not the SSR HTML card), you can emit the same `recipe.show` event using `window.mealz.analytics.attachRecipeCardShowTracking`; see [Recipe card → Custom recipe card](./main-features/recipe-card#custom-recipe-card-show-tracking).
 
 ### Recipe catalog
 

--- a/docs/web_ssr/customization/window-mealz.md
+++ b/docs/web_ssr/customization/window-mealz.md
@@ -42,6 +42,15 @@ props: {aString: 'foo bar', aNumber: 5}
     **Deprecated**, prefer using `supplier.setupWithToken` as it initializes the analytics
   :::
 
+- `attachRecipeCardShowTracking: (options) => { disconnect: () => void }` Attach viewport-based `recipe.show` tracking on a **custom** recipe card root (same rules as `mealz-recipe-card`: ≥80% visible for 1s, deduped until the user scrolls). See [Custom recipe card → recipe.show analytics](../main-features/recipe-card#custom-recipe-card-show-tracking).
+  :::note
+    `options.element`: HTMLElement root to observe (e.g. card wrapper)
+
+    `options.recipeId`: Mealz recipe id
+
+    Call the returned `disconnect()` when the element is removed (virtual lists, SPA navigation).
+  :::
+
 ## window.mealz.basket
 - `basketIsReady$: Observable<boolean>`: Emits true when Mealz's basket has successfully loaded for the first time. Does not emit anything before or after that.
 - `initialize: () => void`: Fetch the first Basket early (before any action requires it on Mealz's side), so you can start the [basket-sync](../set-up-and-usage/basket-synchronization) earlier

--- a/docs/web_ssr/customization/window-mealz.md
+++ b/docs/web_ssr/customization/window-mealz.md
@@ -10,11 +10,11 @@ The window.mealz object still has a lot more methods and attributes that can mak
   Except for the methods mentioned in [Set up and usage](../category/set-up-and-usage), none of the methods listed in this section are necessary if the basic implementation is good enough for you. But if you want or need more customization, you may need to call some of those methods.
 :::
 
-## Need to use window.mealz without a mealz component ?
+## Need to use window.mealz without a mealz component ? {#need-to-use-windowmealz-without-a-mealz-component}
 
 In a typical integration, `window.mealz` becomes available after you inject HTML from a Mealz SSR route (the response includes the Mealz client-side **services** together with the component markup). If you only need the JavaScript API and **do not** want to fetch a Mealz component, you can load **only those services** from a minimal fragment instead.
 
-**V2** adds:
+**V2 only.** Adds:
 
 ```
 GET https://MEALZ_SSR_API_URL/API_VERSION/mealz-window-bootstrap

--- a/docs/web_ssr/main-features/recipe-card.md
+++ b/docs/web_ssr/main-features/recipe-card.md
@@ -304,32 +304,16 @@ And an example of result:
 
 Use this when you render **your own** recipe card UI (not the SSR `<mealz-recipe-card>` HTML) but want the **same** `recipe.show` behaviour as the native card. See [Analytics](../analytics#recipe-card) for how `recipe.show` is defined.
 
-### Step 1 — Load the Web Components SDK
+### Step 1 — Load and initialize the Web Components SDK
 
-Load the WebC / SDK script so `window.mealzInternal.analytics` is available before you attach tracking. This is the same pipeline as the built-in Lit recipe card.
+Load the WebC / SDK script and initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking. This is the same pipeline as the built-in Lit recipe card — see [Set up and usage](../category/set-up-and-usage).
 
-### Step 2 — Load the integration bundle
-
-The SSR API serves a small ES module that exposes the method you will need (`attachRecipeCardShowTracking`):
-
-```
-GET https://MEALZ_SSR_API_URL/v2/client-scripts/recipe-card-show-tracking.js
-```
-
-Load the file as an ES module, for example with dynamic `import()`. Make sure the url is not rewritten at build time, for example if you use Webpack, you'll probably need to add `webpackIgnore: true`.
-
-```js
-const scriptUrl = 'https://MEALZ_SSR_API_URL/v2/client-scripts/recipe-card-show-tracking.js';
-const mod = await import(/* webpackIgnore: true */ scriptUrl);
-const { attachRecipeCardShowTracking } = mod;
-```
-
-### Step 3 — Attach one observer per card root
+### Step 2 — Attach one observer per card root
 
 For each custom card container in the DOM, call:
 
 ```js
-const handle = attachRecipeCardShowTracking({
+const handle = window.mealz.analytics.attachRecipeCardShowTracking({
   element, // HTMLElement: root to observe (e.g. card wrapper)
   recipeId,
 });
@@ -340,3 +324,5 @@ When the node is removed (virtual lists, SPA navigation), call:
 ```js
 handle.disconnect();
 ```
+
+You can listen for emitted events on `window.mealz.analytics.eventSent$` (same stream as other Mealz analytics).

--- a/docs/web_ssr/main-features/recipe-card.md
+++ b/docs/web_ssr/main-features/recipe-card.md
@@ -306,7 +306,31 @@ Use this when you render **your own** recipe card UI (not the SSR `<mealz-recipe
 
 ### Step 1 — Load and initialize the Web Components SDK
 
-Load the WebC / SDK script and initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking. This is the same pipeline as the built-in Lit recipe card — see [Set up and usage](../category/set-up-and-usage).
+When a Mealz SSR component is already on the page, its HTML fragment includes the WebC SDK script tag — `window.mealz` becomes available once that script runs. You can skip this step if another Mealz feature on the same page already loaded the SDK.
+
+If your page uses **only custom recipe cards** and no Mealz SSR component, you must load the SDK yourself before calling `attachRecipeCardShowTracking`. The approach depends on your SSR API version:
+
+#### Option A — Mealz window bootstrap (SSR v2)
+
+**SSR API v2 only.** Fetch a minimal SSR fragment that loads only the SDK (no Lit component markup):
+
+```
+GET https://MEALZ_SSR_API_URL/v2/mealz-window-bootstrap
+```
+
+Inject the returned HTML on the page. Use the same [mandatory HTTP headers](./pre-rendered-components#http-request-headers) as for any other Mealz SSR API request. Details: [window.mealz → without a Mealz component](../customization/window-mealz#need-to-use-windowmealz-without-a-mealz-component).
+
+#### Option B — CDN script tag (SSR v1)
+
+For **SSR API v1** integrations, load the WebC script directly — the same bundle the SSR API injects in its HTML fragments:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/webc-miam@9.1.27/webc-miam-fr.js"></script>
+```
+
+Pick the version and locale file Mealz provides for your integration (`webc-miam-fr.js`, `webc-miam-en.js`, …). See [Web SDK installation](https://docs.mealz.ai/web_sdk/integration/installation) for the full locale list.
+
+Whichever option you use, initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking — see [Set up and usage](../category/set-up-and-usage).
 
 ### Step 2 — Attach one observer per card root
 

--- a/web_ssr_versioned_docs/version-v1/analytics.mdx
+++ b/web_ssr_versioned_docs/version-v1/analytics.mdx
@@ -32,7 +32,7 @@ See [window.mealz.analytics](./customization/window-mealz#windowmealzanalytics) 
   flexDirection="row-reverse"
 />
 
-For a **custom** recipe card (your own DOM, not the SSR HTML card), you can emit the same `recipe.show` event using `attachRecipeCardShowTracking`; see [Recipe card → Custom recipe card](./main-features/recipe-card#custom-recipe-card-show-tracking).
+For a **custom** recipe card (your own DOM, not the SSR HTML card), you can emit the same `recipe.show` event using `window.mealz.analytics.attachRecipeCardShowTracking`; see [Recipe card → Custom recipe card](./main-features/recipe-card#custom-recipe-card-show-tracking).
 
 ### Recipe catalog
 

--- a/web_ssr_versioned_docs/version-v1/customization/window-mealz.md
+++ b/web_ssr_versioned_docs/version-v1/customization/window-mealz.md
@@ -26,6 +26,15 @@ props: {aString: 'foo bar', aNumber: 5}
     **Deprecated**, prefer using `supplier.setupWithToken` as it initializes the analytics
   :::
 
+- `attachRecipeCardShowTracking: (options) => { disconnect: () => void }` Attach viewport-based `recipe.show` tracking on a **custom** recipe card root (same rules as `mealz-recipe-card`: ≥80% visible for 1s, deduped until the user scrolls). See [Custom recipe card → recipe.show analytics](../main-features/recipe-card#custom-recipe-card-show-tracking).
+  :::note
+    `options.element`: HTMLElement root to observe (e.g. card wrapper)
+
+    `options.recipeId`: Mealz recipe id
+
+    Call the returned `disconnect()` when the element is removed (virtual lists, SPA navigation).
+  :::
+
 ## window.mealz.basket
 - `basketIsReady$: Observable<boolean>`: Emits true when Mealz's basket has successfully loaded for the first time. Does not emit anything before or after that.
 - `initialize: () => void`: Fetch the first Basket early (before any action requires it on Mealz's side), so you can start the [basket-sync](../set-up-and-usage/basket-synchronization) earlier

--- a/web_ssr_versioned_docs/version-v1/main-features/recipe-card.md
+++ b/web_ssr_versioned_docs/version-v1/main-features/recipe-card.md
@@ -175,7 +175,23 @@ Use this when you render **your own** recipe card UI (not the SSR `<mealz-recipe
 
 ### Step 1 — Load and initialize the Web Components SDK
 
-Load the WebC / SDK script and initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking. This is the same pipeline as the built-in Lit recipe card — see [Set up and usage](../category/set-up-and-usage).
+When a Mealz SSR component is already on the page, its HTML fragment includes the WebC SDK script tag — `window.mealz` becomes available once that script runs. You can skip this step if another Mealz feature on the same page already loaded the SDK.
+
+If your page uses **only custom recipe cards** and no Mealz SSR component, you must load the SDK yourself before calling `attachRecipeCardShowTracking`.
+
+Add the WebC script directly — the same bundle the SSR API injects in its HTML fragments:
+
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/webc-miam@9.1.30/webc-miam-fr.js"></script>
+```
+
+Pick the version and locale file Mealz provides for your integration (`webc-miam-fr.js`, `webc-miam-en.js`, …). See [Web SDK installation](https://docs.mealz.ai/web_sdk/integration/installation) for the full locale list.
+
+:::info
+SSR API **v2** adds `GET /v2/mealz-window-bootstrap`, a minimal HTML fragment that loads only the SDK without a Lit component. That route is not available on v1 — use the CDN script tag above instead.
+:::
+
+Whichever option you use, initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking — see [Set up and usage](../category/set-up-and-usage).
 
 ### Step 2 — Attach one observer per card root
 

--- a/web_ssr_versioned_docs/version-v1/main-features/recipe-card.md
+++ b/web_ssr_versioned_docs/version-v1/main-features/recipe-card.md
@@ -173,32 +173,16 @@ const recipeCardsHTML = multipleRecipesHTML.split('</mealz-recipe-card>')
 
 Use this when you render **your own** recipe card UI (not the SSR `<mealz-recipe-card>` HTML) but want the **same** `recipe.show` behaviour as the native card. See [Analytics](../analytics#recipe-card) for how `recipe.show` is defined.
 
-### Step 1 — Load the Web Components SDK
+### Step 1 — Load and initialize the Web Components SDK
 
-Load the WebC / SDK script so `window.mealzInternal.analytics` is available before you attach tracking. This is the same pipeline as the built-in Lit recipe card.
+Load the WebC / SDK script and initialize Mealz (`supplier.setupWithToken`, user, POS, language, etc.) so analytics is ready before you attach tracking. This is the same pipeline as the built-in Lit recipe card — see [Set up and usage](../category/set-up-and-usage).
 
-### Step 2 — Load the integration bundle
-
-The SSR API serves a small ES module that exposes the method you will need (`attachRecipeCardShowTracking`):
-
-```
-GET https://MEALZ_SSR_API_URL/v1/client-scripts/recipe-card-show-tracking.js
-```
-
-Load the file as an ES module, for example with dynamic `import()`. Make sure the url is not rewritten at build time, for example if you use Webpack, you'll probably need to add `webpackIgnore: true`.
-
-```js
-const scriptUrl = 'https://MEALZ_SSR_API_URL/v1/client-scripts/recipe-card-show-tracking.js';
-const mod = await import(/* webpackIgnore: true */ scriptUrl);
-const { attachRecipeCardShowTracking } = mod;
-```
-
-### Step 3 — Attach one observer per card root
+### Step 2 — Attach one observer per card root
 
 For each custom card container in the DOM, call:
 
 ```js
-const handle = attachRecipeCardShowTracking({
+const handle = window.mealz.analytics.attachRecipeCardShowTracking({
   element, // HTMLElement: root to observe (e.g. card wrapper)
   recipeId,
 });
@@ -209,3 +193,5 @@ When the node is removed (virtual lists, SPA navigation), call:
 ```js
 handle.disconnect();
 ```
+
+You can listen for emitted events on `window.mealz.analytics.eventSent$` (same stream as other Mealz analytics).


### PR DESCRIPTION
Clarified the usage of `window.mealz.analytics.attachRecipeCardShowTracking` in the analytics and recipe card sections. Added detailed notes on the options for attaching recipe card show tracking and updated the initialization instructions for the Web Components SDK.