### PR TITLE
Update documentation for mealz.basket state notifier

### DIFF
--- a/docs/web_ssr/customization/window-mealz.md
+++ b/docs/web_ssr/customization/window-mealz.md
@@ -60,7 +60,8 @@ props: {aString: 'foo bar', aNumber: 5}
     
     Outside of this usage we don't recommand using `basket.reset()` except to quickly empty Mealz's basket for testing purposes
   :::
-- `recipeCount: () => Observable<number>`: A BehaviorSubject that emits the current number of recipes in Mealz's Basket once (it waits for the Basket to be initialized to emit).
+- `recipeCount: () => Observable<number>`: An Observable that emits the current number of recipes in Mealz's Basket. It waits for the Basket to be initialized before the first emission, then emits again whenever the recipe count changes.
+- `productCount: () => Observable<number>`: An Observable that emits the current number of active products in Mealz's Basket (including standalone products not linked to a recipe). It waits for the Basket to be initialized before the first emission, then emits again whenever the product count changes.
 - `openPreview: () => void`: Opens the recipe-modal in basket preview mode to display the recipes currently in the basket (Same action as when clicking on the FAB in the recipe-catalog)
 
 ## window.mealz.basketSync


### PR DESCRIPTION
Update notification based on changes made to expose a new product count observable (cf. existing recipe count). 
Related PR : https://gitlab.com/miam/ng-miam-sdk/-/merge_requests/1818